### PR TITLE
fix tar command

### DIFF
--- a/course-migrate/migrate-course.py
+++ b/course-migrate/migrate-course.py
@@ -338,7 +338,7 @@ os.system('chmod  777 -R ' + sourceDir+'migrated/' )
 
 for f in files:
     fname = f[sourceDirLen:] #Remove the path from full file name. Now have only file name
-    os.system('tar cfz '+sourceDir+'output/'+fname+' ' + sourceDir+'migrated/'+fname+'/course')
+    os.system('tar cfz '+sourceDir+'output/'+fname+' --directory="' + sourceDir+'migrated/'+fname+'" course')
 
 print 'Created output tar.gaz files under ' +sourceDir+'output/'
 # Give everymody read right so that import command doesn't need sudo right. File is creted with root:root


### PR DESCRIPTION
First, thanks for share this great tool. While using it I’ve found an error with the tar command, is keeping the directory structure inside the result tar.gz file, so I have changed the command for to get the `course` folder right after you extract the tar file. I hope this will be useful to you.